### PR TITLE
WIP: Fix the parameter order for register_alias on items.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -129,15 +129,15 @@ end
 
 -- Aliases --
 
-minetest.register_alias("air", "draconis:dracolily_fire")
-minetest.register_alias("air", "draconis:dracolily_ice")
+minetest.register_alias("draconis:dracolily_fire", "air")
+minetest.register_alias("draconis:dracolily_ice", "air")
 
 for color in pairs(draconis.colors_ice) do
-    minetest.register_alias("draconis:egg_ice_" .. color, "draconis:egg_ice_dragon_" .. color)
+    minetest.register_alias("draconis:egg_ice_dragon_" .. color, "draconis:egg_ice_" .. color)
 end
 
 for color in pairs(draconis.colors_fire) do
-    minetest.register_alias("draconis:egg_fire_" .. color, "draconis:egg_fire_dragon_" .. color)
+    minetest.register_alias("draconis:egg_fire_dragon_" .. color, "draconis:egg_fire_" .. color)
 end
 
 minetest.register_entity("draconis:ice_eyes", {

--- a/nodes.lua
+++ b/nodes.lua
@@ -666,8 +666,6 @@ for color in pairs(draconis.colors_fire) do
 	minetest.register_alias_force("draconis:egg_fire_" .. color, "draconis:egg_fire_" .. color)
 end
 
-minetest.register_alias_force("draconis:dracolily_ice", "")
-minetest.register_alias_force("draconis:dracolily_fire", "")
 minetest.register_alias_force("draconis:growth_essence_ice", "")
 minetest.register_alias_force("draconis:growth_essence_fire", "")
 minetest.register_alias_force("draconis:blood_ice_dragon", "")


### PR DESCRIPTION
The parameter order for the minetest.register_alias call is inverted on init.lua. This pull request fixes that.

Fixes #19