### PR TITLE
Prevent dragons from destroying bones

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -1161,7 +1161,8 @@ draconis.dragon_api = {
 				if n_pos.y - pos.y >= 1 then
 					local node = minetest.get_node(n_pos)
 					if minetest.get_item_group(node.name, "cracky") ~= 1
-					and minetest.get_item_group(node.name, "unbreakable") < 1 then
+					and minetest.get_item_group(node.name, "unbreakable") < 1
+					and node.name ~= "bones:bones" then
 						if random(6) < 2 then
 							minetest.dig_node(n_pos)
 						else

--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -166,7 +166,8 @@ local function destroy_terrain(self, dir)
 			or dir.y < 0 then
 				local node = minetest.get_node(n_pos)
 				if minetest.get_item_group(node.name, "cracky") ~= 1
-				and minetest.get_item_group(node.name, "unbreakable") < 1 then
+				and minetest.get_item_group(node.name, "unbreakable") < 1
+				and node.name ~= "bones:bones" then
 					if random(6) < 2 then
 						minetest.dig_node(n_pos)
 					else


### PR DESCRIPTION
Currently, if a dragon kills a player and bones are dropped, the dragon can then destroy the players bones during flight, potentially causing item loss. This PR adds a check to make sure the dragons are not removing bone blocks when destroying terrain.