### PR TITLE
Superficially fix basic mcl support

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -1334,7 +1334,7 @@ draconis.dragon_api = {
 		end
 		local item, item_name = self:follow_wielded_item(player)
 		if item_name then
-			if not minetest.is_creative_enabled(player) then
+			if not minetest.is_creative_enabled(player:get_player_name()) then
 				item:take_item()
 				player:set_wielded_item(item)
 			end
@@ -1514,7 +1514,7 @@ draconis.wyvern_api = {
 		end
 		local item, item_name = self:follow_wielded_item(player)
 		if item_name then
-			if not minetest.is_creative_enabled(player) then
+			if not minetest.is_creative_enabled(player:get_player_name()) then
 				item:take_item()
 				player:set_wielded_item(item)
 			end

--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -139,7 +139,7 @@ local function find_target(self, list)
 	local targets = creatura.get_nearby_players(self)
 	if #targets > 0 then -- If there are players nearby
 		local target = targets[random(#targets)]
-		local is_creative = target:is_player() and minetest.is_creative_enabled(target)
+		local is_creative = target:is_player() and minetest.is_creative_enabled(target:get_player_name())
 		local is_owner = owner and target == owner
 		if is_creative or is_owner then targets = {} end
 	end

--- a/craftitems.lua
+++ b/craftitems.lua
@@ -108,7 +108,7 @@ minetest.register_craftitem("draconis:draconic_steel_ingot_ice", {
 ----------
 
 local function egg_rightclick(self, clicker, item)
-	if not minetest.is_creative_enabled(clicker) then
+	if not minetest.is_creative_enabled(clicker:is_player() and clicker:get_player_name() or "") then
 		local inv = clicker:get_inventory()
 		if inv:room_for_item("main", {name = item}) then
 			clicker:get_inventory():add_item("main", item)

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = draconis
 depends = creatura
-optional_depends = default, mcl_player, stairs, 3d_armor
+optional_depends = default, mcl_player, stairs, 3d_armor, mcl_core
 description = Adds advanced Dragons and powerful equipment
 title = Draconis
 

--- a/nodes.lua
+++ b/nodes.lua
@@ -9,12 +9,13 @@ local random = math.random
 -- Get Craft Items --
 
 local steel_ingot = "default:steel_ingot"
-
+local stack_size = 99
 minetest.register_on_mods_loaded(function()
-	for name in pairs(minetest.registered_items) do
+	for name, def in pairs(minetest.registered_items) do
 		if name:match(":steel_ingot") or name:match(":ingot_steel")
 		or name:match(":iron_ingot") or name:match(":ingot_iron") then
 			steel_ingot = name
+			stack_size = def.stack_max or stack_size
 			break
 		end
 	end
@@ -250,8 +251,6 @@ register_node("draconis:bone_pile_frozen", {
 --------------------------
 -- Draconic Steel Forge --
 --------------------------
-
-local stack_size = minetest.registered_items[steel_ingot].stack_max or 99
 
 local forge_core = {
 	["draconis:draconic_forge_fire"] = "draconis:dragonstone_block_fire",


### PR DESCRIPTION
This fixes 2 issues that kept the mod from running in mcl (there are probably more but with this it doesn't crash on load or spawning dragon):

Fixes #34 
Fixes #32

* Fix instances where minetest.is_creative_enabled is wrongly called with the object
* Fix a too early access of the "steel_ingot" variable in nodes.lua which is only ultimately set on_mods_loaded when using mcl (or another game that doesn't have an item name containing "steel_ingot" but one containing "iron_ingot" to be precise)