### PR TITLE
Set turn_rate on ice dragon

### DIFF
--- a/mobs/ice_dragon.lua
+++ b/mobs/ice_dragon.lua
@@ -24,6 +24,7 @@ creatura.register_mob("draconis:ice_dragon", {
 	max_breath = 0,
 	armor_groups = {fleshy = 50},
 	damage = 20,
+	turn_rate = 2,
 	speed = 24,
 	tracking_range = 64,
 	despawn_after = false,


### PR DESCRIPTION
This fixes a null pointer exception raised when `turn_rate` is nil.

I don't know how to reproduce the problem but it suddenly started crashing my daughter's world (which had already had some ice dragons for some time) and this appears to fix it!

#43 addresses the same problem when `turn_rate` is used in the behaviour api. We might need both approaches if `turn_rate` can become nil after initialisation.